### PR TITLE
Subtask graph

### DIFF
--- a/js/todo_modal.js
+++ b/js/todo_modal.js
@@ -232,18 +232,14 @@ let Modal = {
 				if (response.ok) {
 					const data = response.data;
 					let new_task = Task.create_task(data[0]);
+					let old_task = document.getElementById("task_id:" + data[0].task_id);
+					old_task.parentElement.replaceChild(new_task, old_task);
+
 					if (data[0].parent === null) {
-						// parentに値がなければ、それは親タスク
-						let old_task = document.getElementById("task_id:" + data[0].task_id);
-						old_task.parentElement.replaceChild(new_task, old_task);
+						// parentに値がなければ、親タスク
 						Task.get_child(data[0].task_id);
 					} else {
-						console.log(new_task);
-						// parentに値があれば、それはサブタスク
 						new_task.classList.add("sub");
-						// 自分自身を見つけて、入れ替える
-						let old_task = document.getElementById("task_id:" + data[0].task_id);
-						old_task.parentElement.replaceChild(new_task, old_task);
 					}
 				}
 				Modal.remove();

--- a/js/todo_simple.js
+++ b/js/todo_simple.js
@@ -43,7 +43,6 @@ let Task = {
 	// クリックされたら、状態を更新する
 	// 変化した先の状態を送る
 	change_status: function(event) {
-
 		let task = Base.parents(event.target, "task");
 		// 実行前、タスクの情報が付加されていない場合は一旦止める
 		if (Task._check_detail_empty(task) || Task._check_plan_empty(task)) {
@@ -178,13 +177,20 @@ let Task = {
 		}).send(null);
 	},
 
-	get_child: function() {
-		let parents = Object.keys(Task.tree);
+	get_child: function(parent_id) {
+		let parents = null;
+		if (parent_id) {
+			// 引数があれば、それを
+			parents = [parent_id];
+		} else {
+			// 引数がなければ、ページ全体の
+			parents = Object.keys(Task.tree);
+		}
 		// console.log(parents);
-		parents.forEach(function(parent_id) {
+		parents.forEach(function(parent) {
 			let query = [
 				"?cmd=task_child",
-				"&parent=", parent_id,
+				"&parent=", parent,
 				"&user_id=" + Base.get_cookie("user_id"),
 			].join("");
 			Base.create_request("GET", Base.request_path + query, function() {
@@ -215,10 +221,12 @@ let Task = {
 						let sublist = parent.querySelector(".subtask_list");
 						sublist.appendChild(fragment);
 
-						let tasks = document.querySelectorAll(".task");
-						for (i = 0; i < tasks.length; i++) {
-							ProgressTimer.display(tasks[i]);
-						}
+						// let tasks = document.querySelectorAll(".task");
+						// for (i = 0; i < tasks.length; i++) {
+						// 	ProgressTimer.display(tasks[i]);
+						// }
+						console.log("get_child", parent.id);
+						ProgressTimer.display(parent);
 					}
 				}
 			}).send(null);

--- a/ruby/process_subtree.rb
+++ b/ruby/process_subtree.rb
@@ -175,18 +175,10 @@ def task_modify(cgi)
   # timeを修正
   $client.prepare(sql + 'actual_time =  ?' + where).execute(cgi[:time], user_id, task_id) unless cgi[:time].nil? || cgi[:time].to_s.empty?
 
-  # 親タスクの時は、parent_id=自分自身
-  # 子タスクの時は、parent_id=親のID
-  parent_id = if cgi[:parent].to_s.empty?
-    cgi[:task_id]
-              else
-    cgi[:parent]
-              end
-
   # 修正した結果を取得する
-  search = 'select * from task left outer join task_tree on task_id = child where user_id = ? and (task_id = ? or parent = ?) order by task_id'
-  # サブタスクを取得する
-  result = $client.prepare(search).execute(user_id, parent_id, parent_id)
+  search = 'select * from task left outer join task_tree on task_id = child where user_id = ? and task_id = ?'
+  result = $client.prepare(search).execute(user_id, cgi[:task_id])
+
   { ok: true, data: result.entries }
 end
 


### PR DESCRIPTION
get_childが常にすべての親タスクの子供を取得するようになっていたため、親要素を書き換えたとき他のタスクもサブタスクが増えるというクソ仕様だった。

そこで、get_childに引数をもたせ
・引数あり：引数のタスクのサブタスクのみもらってくる
・引数なし：すべてのタスクのサブタスクをもらってくる
ようにした。